### PR TITLE
Fix issue parsing zones < 10 with leading '0' character.

### DIFF
--- a/smartthings-nodeproxy/avail_plugins/envisalink.js
+++ b/smartthings-nodeproxy/avail_plugins/envisalink.js
@@ -269,7 +269,7 @@ function Envisalink () {
     var msg = {};
     msg.partitionNumber = parseInt(map[0]);
     msg.flags = getLedFlag(map[1]);
-    msg.userOrZone = parseInt(map[2]);
+    msg.userOrZone = parseInt(map[2], 10);
     msg.beep = VIRTUAL_KEYPAD_BEEP[map[3]];
     msg.alpha = map[4].trim();
     msg.dscCode = getDscCode(msg.flags);


### PR DESCRIPTION
I noticed an issue with zones < 10 not generating open/closed events properly. This is because `parseInt` parses a zone like `08` as zero.