### PR TITLE
Moved setInterval to be outside of init

### DIFF
--- a/smartthings-nodeproxy/avail_plugins/envisalink.js
+++ b/smartthings-nodeproxy/avail_plugins/envisalink.js
@@ -140,6 +140,9 @@ function Envisalink () {
     write(deviceRequest);
   };
 
+  // check connection every 60 secs
+  setInterval(function() { self.init(); }, 60*1000);
+
   /**
    * init
    */
@@ -175,9 +178,6 @@ function Envisalink () {
       logger('Connected to Envisalink at '+nconf.get('envisalink:address')+':'+nconf.get('envisalink:port'));
     });
   };
-
-  // check connection every 60 secs
-  setInterval(function() { self.init(); }, 60*1000);
 
   // experimental: dump zone timers
   var zoneTimer = (nconf.get('envisalink:dumpZoneTimer')) ? parseInt(nconf.get('envisalink:dumpZoneTimer')) : 0;


### PR DESCRIPTION
The setInterval to reset the connection was inside of the init function
so every time that it triggers init, setInterval will be registered
again. This adds a new call to init once every minute, which is
potentially detrimental.