### PR TITLE
Use local source tree to build container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.DS_Store
+smartthings-nodeproxy/config.json
+smartthings-nodeproxy/node_modules
+smartthings-nodeproxy/plugins
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,17 +26,19 @@ ENV NODE=/usr/local/bin/node
 ENV NPM=/usr/local/bin/npm
 ENV PYTHON=/usr/bin/python2.7
 
-ADD smartthings-nodeproxy /stnp
+ADD smartthings-nodeproxy/package.json /stnp/package.json
 WORKDIR /stnp
 RUN mkdir -p /stnp/plugins
 RUN apt-get install python2.7 build-essential libpcap-dev wget \
- && rm -f restart.me smartthings-nodeproxy.service config.json \
  && npm install \
  && npm install serialport@4.0.7 \
  && npm install https://github.com/node-pcap/node_pcap/tarball/master \
  && apt-get remove --auto-remove wget build-essential libpcap-dev libpcap0.8-dev --purge \
  && apt-get clean \
  && rm -rf /tmp/* 
+
+ADD smartthings-nodeproxy /stnp
+RUN rm -f restart.me smartthings-nodeproxy.service config.json
 
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
 COPY docker/config.sample /stnp/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,10 @@ ENV NODE=/usr/local/bin/node
 ENV NPM=/usr/local/bin/npm
 ENV PYTHON=/usr/bin/python2.7
 
+ADD smartthings-nodeproxy /stnp
+WORKDIR /stnp
+RUN mkdir -p /stnp/plugins
 RUN apt-get install python2.7 build-essential libpcap-dev wget \
- && mkdir -p /stnp/plugins \
- && wget -O - https://github.com/${repo}/smartthings/tarball/${branch} \
-  | tar -xzvf - --wildcards --strip-components=2 -C /stnp/ ${repo}-smartthings-*/smartthings-nodeproxy/ \
- && cd /stnp \
  && rm -f restart.me smartthings-nodeproxy.service config.json \
  && npm install \
  && npm install serialport@4.0.7 \
@@ -39,8 +38,8 @@ RUN apt-get install python2.7 build-essential libpcap-dev wget \
  && apt-get clean \
  && rm -rf /tmp/* 
 
-COPY docker-entrypoint.sh /docker-entrypoint.sh
-COPY config.sample /stnp/config.json
+COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker/config.sample /stnp/config.json
 
 EXPOSE 8080
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ Optionally, you can add the `pi` user to the `docker` group and avoid having to 
 
 # Build a Docker Container
 
-Build a Docker container with the `docker build` command. Specify custom build arguments as necessary:
+Build a Docker container by running the `docker build` command from the root of this project. Specify custom build arguments as necessary:
 
 ```
 docker build -t smartthings-node-proxy:latest .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   #Rename, add, or change the name of the service as necessary
   stnp:
     #Specify build if you have the Dockerfile etc and need to build a new version. Otherwise use image.
-    build: .
+    build: ..
     image: rpi-smartthings-nodeproxy:latest
     ports:
       - "8080:8080"


### PR DESCRIPTION
@tcjennings Let me know if there was a reason to download the latest from GitHub on build rather than using the local source tree. This flow is making it much faster to iterate on changes, as I don't need to push to GitHub to do a `docker build`.