### PR TITLE
Add ability to set Partition to Armed Instant when Home Monitor set to Home Armed

### DIFF
--- a/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
+++ b/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
@@ -56,7 +56,7 @@ def page1() {
 
     section("Smart Home Monitor") {
       input "enableSHM", "bool", title: "Integrate with Smart Home Monitor", required: true, defaultValue: true
-      input "useStayInstant", "bool", title: "Use Arm Instant when handling setting stay from Smart Home Monitor", required: true, defaultValue: false
+      input "useArmInstant", "bool", title: "Use \"Arm Instant\" when Smart Home Monitor set to Armed (Home)", required: false, defaultValue: false
     }
   }
 }
@@ -227,9 +227,10 @@ def alarmHandler(evt) {
 
   state.alarmSystemStatus = evt.value
   if (evt.value == "stay") {
-    if (useStayInstant.useStayInstant) {
+    if (settings.useArmInstant) {
       sendCommandPlugin('/armInstant')
-    } else {
+    } 
+    else {
       sendCommandPlugin('/armStay')
     }
   }

--- a/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
+++ b/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
@@ -56,6 +56,7 @@ def page1() {
 
     section("Smart Home Monitor") {
       input "enableSHM", "bool", title: "Integrate with Smart Home Monitor", required: true, defaultValue: true
+      input "useStayInstant", "bool", title: "Use Arm Instant when handling setting stay from Smart Home Monitor", required: true, defaultValue: false
     }
   }
 }
@@ -226,7 +227,11 @@ def alarmHandler(evt) {
 
   state.alarmSystemStatus = evt.value
   if (evt.value == "stay") {
-    sendCommandPlugin('/armStay')
+    if (useStayInstant.useStayInstant) {
+      sendCommandPlugin('/armInstant')
+    } else {
+      sendCommandPlugin('/armStay')
+    }
   }
   if (evt.value == "away") {
     sendCommandPlugin('/armAway')


### PR DESCRIPTION
I prefer to have my alarm set to ":Instant" when I'm home and armed, so that there is no entry delay on the doors if I'm home and sleeping.  Added this configuration for my setup and wanted to share.