### PR TITLE
Update honeywell-zone-water.groovy

### DIFF
--- a/devicetypes/redloro-smartthings/honeywell-zone-water.src/honeywell-zone-water.groovy
+++ b/devicetypes/redloro-smartthings/honeywell-zone-water.src/honeywell-zone-water.groovy
@@ -51,5 +51,5 @@ def zone(String state) {
   ]
   def desc = descMap."${state}"
 
-  sendEvent (name: "water", value: "${newstate}", descriptionText: "${desc}")
+  sendEvent (name: "water", value: "${newState}", descriptionText: "${desc}")
 }


### PR DESCRIPTION
Had to capitalize S in '${newState} for it to be properly recognized in SmartThings. Simple typo correction.