### PR TITLE
Control new SHM, trigger siren

### DIFF
--- a/devicetypes/redloro-smartthings/honeywell-partition.src/honeywell-partition.groovy
+++ b/devicetypes/redloro-smartthings/honeywell-partition.src/honeywell-partition.groovy
@@ -41,6 +41,7 @@ metadata {
     command "keyD"
     command "chime"
     command "bypass"
+    command "soundSiren"
   }
 
   tiles(scale: 2) {
@@ -128,6 +129,7 @@ metadata {
 
   preferences {
     input name: "bypassZones", type: "text", title: "Bypass Zones", description: "Comma delimited list of zones to bypass", required: false
+    input name: "sirenKey", type: "text", title: "Siren Key", description: "Speedy Key (ABCD) to trigger to sound siren", required: false
   }
 }
 
@@ -214,6 +216,18 @@ def keyC() {
 
 def keyD() {
   sendPartitionCommand('speedkey/D')
+}
+
+def soundAlarm() {
+  sendPartitionCommand('speedkey/${settings.sirenKey}')
+}
+
+def both() {
+  soundAlarm()
+}
+
+def siren() {
+  soundAlarm()
 }
 
 def getPrettyName()

--- a/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
+++ b/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
@@ -81,6 +81,9 @@ def page1() {
 
     section("Smart Home Monitor") {
       input "enableSHM", "bool", title: "Integrate with Smart Home Monitor", required: true, defaultValue: true
+      input "armStaySHM", "capability.switch", title: "SHM Arm Stay virtual switch", required: true
+      input "armAwaySHM", "capability.switch", title: "SHM Arm Away virtual switch", required: true
+      input "disarmSHM", "capability.switch", title: "SHM Disarm virtual switch", required: true
     }
     
     section("Logging") {
@@ -364,13 +367,28 @@ private updateAlarmSystemStatus(partitionstatus) {
 
   def lastAlarmSystemStatus = state.alarmSystemStatus
   if (partitionstatus == "armedstay" || partitionstatus == "armedinstant") {
-    state.alarmSystemStatus = "stay"
+    //state.alarmSystemStatus = "stay"
+    if (armStaySHM.latestState("switch").value == "off") {
+        armStaySHM.on()
+    } else {
+        armStaySHM.off()
+    }
   }
   if (partitionstatus == "armedaway" || partitionstatus == "armedmax") {
-    state.alarmSystemStatus = "away"
+    //state.alarmSystemStatus = "away"
+    if (armAwaySHM.latestState("switch").value == "off") {
+        armAwaySHM.on()
+    } else {
+        armAwaySHM.off()
+    }
   }
   if (partitionstatus == "ready") {
-    state.alarmSystemStatus = "off"
+    //state.alarmSystemStatus = "off"
+    if (disarmSHM.latestState("switch").value == "off") {
+        disarmSHM.on()
+    } else {
+        disarmSHM.off()
+    }
   }
 
   if (lastAlarmSystemStatus != state.alarmSystemStatus) {


### PR DESCRIPTION
Added the ability to control the new SHM with virtual switches. User will have to manually add 3 switches (Stay/Away/Off) and create automations to let those switches control SHM accordingly. The switches are defined in the SmartApp settings page.

Added the ability for SHM to trigger the physical siren via physical speed key (ABCD). The setting is configured in the Partition's device settings. By default most Honeywell alarms have the B speed key set to Police Panic.