### PR TITLE
SHM Control, physical siren trigger, bugfix

### DIFF
--- a/devicetypes/redloro-smartthings/honeywell-partition.src/honeywell-partition.groovy
+++ b/devicetypes/redloro-smartthings/honeywell-partition.src/honeywell-partition.groovy
@@ -41,6 +41,7 @@ metadata {
     command "keyD"
     command "chime"
     command "bypass"
+    command "soundSiren"
   }
 
   tiles(scale: 2) {
@@ -128,6 +129,7 @@ metadata {
 
   preferences {
     input name: "bypassZones", type: "text", title: "Bypass Zones", description: "Comma delimited list of zones to bypass", required: false
+    input name: "sirenKey", type: "text", title: "Siren Key", description: "Speedy Key (ABCD) to trigger to sound siren", required: false
   }
 }
 
@@ -214,6 +216,18 @@ def keyC() {
 
 def keyD() {
   sendPartitionCommand('speedkey/D')
+}
+
+def soundAlarm() {
+  sendPartitionCommand('speedkey/${settings.sirenKey}')
+}
+
+def both() {
+  soundAlarm()
+}
+
+def siren() {
+  soundAlarm()
 }
 
 def getPrettyName()

--- a/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
+++ b/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
@@ -368,26 +368,32 @@ private updateAlarmSystemStatus(partitionstatus) {
   def lastAlarmSystemStatus = state.alarmSystemStatus
   if (partitionstatus == "armedstay" || partitionstatus == "armedinstant") {
     //state.alarmSystemStatus = "stay"
-    if (armStaySHM.latestState("switch").value == "off") {
-        armStaySHM.on()
+    if (armStaySHM.latestState("switch").value == "on") {
+    	//already armed
     } else {
-        armStaySHM.off()
+        armStaySHM.on()
+        armAwaySHM.off()
+        disarmSHM.off()
     }
   }
   if (partitionstatus == "armedaway" || partitionstatus == "armedmax") {
     //state.alarmSystemStatus = "away"
-    if (armAwaySHM.latestState("switch").value == "off") {
-        armAwaySHM.on()
+    if (armAwaySHM.latestState("switch").value == "on") {
+        //already armed
     } else {
-        armAwaySHM.off()
+        armStaySHM.off()
+        armAwaySHM.on()
+        disarmSHM.off()
     }
   }
   if (partitionstatus == "ready") {
     //state.alarmSystemStatus = "off"
-    if (disarmSHM.latestState("switch").value == "off") {
-        disarmSHM.on()
+    if (disarmSHM.latestState("switch").value == "on") {
+        //already disarmed
     } else {
-        disarmSHM.off()
+        armStaySHM.off()
+        armAwaySHM.off()
+        disarmSHM.on()
     }
   }
 

--- a/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
+++ b/smartapps/redloro-smartthings/honeywell-security.src/honeywell-security.groovy
@@ -81,6 +81,9 @@ def page1() {
 
     section("Smart Home Monitor") {
       input "enableSHM", "bool", title: "Integrate with Smart Home Monitor", required: true, defaultValue: true
+      input "armStaySHM", "capability.switch", title: "SHM Arm Stay virtual switch", required: true
+      input "armAwaySHM", "capability.switch", title: "SHM Arm Away virtual switch", required: true
+      input "disarmSHM", "capability.switch", title: "SHM Disarm virtual switch", required: true
     }
     
     section("Logging") {
@@ -364,13 +367,28 @@ private updateAlarmSystemStatus(partitionstatus) {
 
   def lastAlarmSystemStatus = state.alarmSystemStatus
   if (partitionstatus == "armedstay" || partitionstatus == "armedinstant") {
-    state.alarmSystemStatus = "stay"
+    //state.alarmSystemStatus = "stay"
+    if (armStaySHM.latestState("switch").value == "off") {
+        armStaySHM.on()
+    } else {
+        armStaySHM.off()
+    }
   }
   if (partitionstatus == "armedaway" || partitionstatus == "armedmax") {
-    state.alarmSystemStatus = "away"
+    //state.alarmSystemStatus = "away"
+    if (armAwaySHM.latestState("switch").value == "off") {
+        armAwaySHM.on()
+    } else {
+        armAwaySHM.off()
+    }
   }
   if (partitionstatus == "ready") {
-    state.alarmSystemStatus = "off"
+    //state.alarmSystemStatus = "off"
+    if (disarmSHM.latestState("switch").value == "off") {
+        disarmSHM.on()
+    } else {
+        disarmSHM.off()
+    }
   }
 
   if (lastAlarmSystemStatus != state.alarmSystemStatus) {


### PR DESCRIPTION
Added the ability to control SHM via virtual switches. The switches are defined on the Preference page of the SmartApp.

Added the ability to define a speed key (ABCD) to be executed as a SHM siren. The Speed Key is selected in the Partition Device's settings. Honeywell typically defaults the B key to Police Panic. If the B key is selected in the settings, when the SHM siren event fires, the Honeywell siren will sound.

Multi activation bugfix: It was late and my brain wasn't working so I inadvertently triggered the virtual switch changes with any zone change. This has been resolved.